### PR TITLE
clean up pia format - serialized and deserialized first two data lines

### DIFF
--- a/src/library/PiaFormat.ts
+++ b/src/library/PiaFormat.ts
@@ -6,8 +6,12 @@ type Dictionary<K extends string | number, V> = Partial<Record<K, V>>;
 // Map from line ID to full line string
 type PIALineMap = Dictionary<number, string>;
 
+class PIADate extends Date {}
+
+class PIAMonthYear extends Date {}
+
 interface PIASerializer {
-  field_formats: Record<string, PIAFieldMeta>;
+  fieldFormats: Record<string, PIAFieldMeta>;
   serialize: (data: Partial<PIAData>) => PIALineMap;
   deserialize: (lineMap: PIALineMap) => Partial<PIAData>;
 }
@@ -29,9 +33,9 @@ class PIAFieldMeta {
 return ['01', this.ssn, this.sex, dayjs(this.birthDate).format("MMDDYYYY"),'\n', this.piaEverythingElse.join('\n')].join('');
 */
 const basicInfoSerializer: PIASerializer = new (class {
-  field_formats: Record<string, PIAFieldMeta>;
+  fieldFormats: Record<string, PIAFieldMeta>;
   constructor() {
-    this.field_formats = {
+    this.fieldFormats = {
       ssn: new PIAFieldMeta(3, 11),
       birthDate: new PIAFieldMeta(13, 20),
       dateOfDeath: new PIAFieldMeta(3, 10),
@@ -42,24 +46,24 @@ const basicInfoSerializer: PIASerializer = new (class {
   serialize(data: Partial<PIAData>): PIALineMap {
     const line01 = {
       1: `01${
-        data.ssn != undefined ? data.ssn : this.field_formats.ssn.getBlank()
+        data.ssn != undefined ? data.ssn : this.fieldFormats.ssn.getBlank()
       }${data.sex != undefined ? data.sex : " "}${
         data.birthDate != undefined
-          ? dayjs(data.birthDate).format("MMDDYYYY")
-          : this.field_formats.birthDate.getBlank()
+          ? formatPIAMonthStr(data.birthDate)
+          : this.fieldFormats.birthDate.getBlank()
       }`,
     };
     const line02 = {
       2: `02${
         data.dateOfDeath != undefined
-          ? dayjs(data.dateOfDeath).format("MMDDYYYY")
-          : this.field_formats.dateOfDeath.getBlank()
+          ? formatPIAMonthStr(data.dateOfDeath)
+          : this.fieldFormats.dateOfDeath.getBlank()
       }`,
     };
 
     return { ...line01, ...line02 };
   }
-  deserialize(lineMap: PIALineMap, data: Partial<PIAData>): Partial<PIAData> {
+  deserialize(lineMap: PIALineMap): Partial<PIAData> {
     const line01Str = lineMap[1];
     const line02Str = lineMap[2];
 
@@ -67,18 +71,18 @@ const basicInfoSerializer: PIASerializer = new (class {
       ? {
           ssn: parsePiaString(
             line01Str,
-            this.field_formats.ssn.start,
-            this.field_formats.ssn.end
+            this.fieldFormats.ssn.start,
+            this.fieldFormats.ssn.end
           ),
           birthDate: parsePiaDate(
             line01Str,
-            this.field_formats.birthDate.start,
-            this.field_formats.birthDate.end
+            this.fieldFormats.birthDate.start,
+            this.fieldFormats.birthDate.end
           ),
           sex: parsePiaSex(
             line01Str,
-            this.field_formats.sex.start,
-            this.field_formats.sex.end
+            this.fieldFormats.sex.start,
+            this.fieldFormats.sex.end
           ),
         }
       : {};
@@ -89,12 +93,74 @@ const basicInfoSerializer: PIASerializer = new (class {
           dateOfDeath: parsePiaDate(line02Str, 3, 10),
         }
       : {};
-    return { ...line01Data, line02Data };
+    return { ...line01Data, ...line02Data };
+  }
+})();
+
+const benefitSerializer: PIASerializer = new (class {
+  fieldFormats: Record<string, PIAFieldMeta>;
+  constructor() {
+    this.fieldFormats = {
+      typeOfBenefit: new PIAFieldMeta(3, 3),
+      monthYearEntitlement: new PIAFieldMeta(4, 9),
+      monthYearBenefit: new PIAFieldMeta(3, 8),
+    };
+  }
+  serialize(data: Partial<PIAData>): PIALineMap {
+    const line03 = {
+      3: `03${
+        data.typeOfBenefit != undefined
+          ? data.typeOfBenefit
+          : this.fieldFormats.typeOfBenefit.getBlank()
+      }${
+        data.monthYearEntitlement != undefined
+          ? formatPIAMonthStr(data.monthYearEntitlement)
+          : this.fieldFormats.monthYearEntitlement.getBlank()
+      }`,
+    };
+    const line04 = {
+      4: `04${
+        data.monthYearBenefit != undefined
+          ? formatPIAMonthStr(data.monthYearBenefit)
+          : this.fieldFormats.monthYearBenefit.getBlank()
+      }`,
+    };
+
+    return { ...line03, ...line04 };
+  }
+  deserialize(lineMap: PIALineMap): Partial<PIAData> {
+    let line03 = lineMap[3];
+    let line04 = lineMap[4];
+    let line03Data = line03
+      ? {
+          typeOfBenefit: parseSSABenefitType(
+            line03,
+            this.fieldFormats.typeOfBenefit.start,
+            this.fieldFormats.typeOfBenefit.end
+          ),
+          monthYearEntitlement: parsePiaMonthYear(
+            line03,
+            this.fieldFormats.monthYearEntitlement.start,
+            this.fieldFormats.monthYearEntitlement.end
+          ),
+        }
+      : {};
+    let line04Data = line04
+      ? {
+          monthYearEntitlement: parsePiaMonthYear(
+            line04,
+            this.fieldFormats.monthYearEntitlement.start,
+            this.fieldFormats.monthYearEntitlement.end
+          ),
+        }
+      : {};
+    return { ...line03Data, ...line04Data };
   }
 })();
 
 const PIA_SERIALIZERS: PIASerializer[] = [
   basicInfoSerializer,
+  benefitSerializer,
   // dateOfDeathSerializer,
   // disabilityDatesSerializer,
   //…
@@ -134,11 +200,20 @@ enum PIASex {
   female = 1,
 }
 
+enum SSABenefitType {
+  old_age = 1,
+  survivor = 2,
+  disability = 3,
+}
+
 interface PIAData {
   ssn?: string;
-  birthDate?: Date;
-  dateOfDeath?: Date;
+  birthDate?: PIADate;
+  dateOfDeath?: PIADate;
   sex?: PIASex;
+  typeOfBenefit?: SSABenefitType;
+  monthYearBenefit?: PIAMonthYear;
+  monthYearEntitlement?: PIAMonthYear;
   oasdiEarnings?: Array<number>;
   firstEarningYearActual?: number;
   lastEarningYearActual?: number;
@@ -170,7 +245,11 @@ function parsePiaString(str: string, start: number, end: number): string {
   return piaSubstr(str, start, end);
 }
 
-function parsePiaMonth(lineStr: string, start: number, end: number): Date {
+function parsePiaMonthYear(
+  lineStr: string,
+  start: number,
+  end: number
+): PIAMonthYear {
   let ymStr = piaSubstr(lineStr, start, end);
   var djs = dayjs();
   let year = ymStr.slice(0, 2);
@@ -179,7 +258,8 @@ function parsePiaMonth(lineStr: string, start: number, end: number): Date {
     .set("month", parseInt(month, 10))
     .set("year", parseInt(year, 10))
     .set("day", 1);
-  return djs.toDate();
+  var piaMonth: PIAMonthYear = djs.toDate();
+  return piaMonth;
 }
 
 function parsePiaSex(lineStr: string, start: number, end: number): PIASex {
@@ -189,7 +269,18 @@ function parsePiaSex(lineStr: string, start: number, end: number): PIASex {
   return sex;
 }
 
-function parsePiaDate(lineStr: string, start: number, end: number): Date {
+function parseSSABenefitType(
+  lineStr: string,
+  start: number,
+  end: number
+): SSABenefitType {
+  let benStr = piaSubstr(lineStr, start, end);
+  let benInt = parseInt(benStr);
+  let ssaBen: SSABenefitType = benInt;
+  return ssaBen;
+}
+
+function parsePiaDate(lineStr: string, start: number, end: number): PIADate {
   var djs = dayjs();
   let ymdStr = piaSubstr(lineStr, start, end);
   let year = ymdStr.slice(0, 2);
@@ -201,7 +292,8 @@ function parsePiaDate(lineStr: string, start: number, end: number): Date {
     .set("month", parseInt(month, 10))
     .set("year", parseInt(year, 10))
     .set("date", parseInt(day, 10));
-  return djs.toDate();
+  let piaDate: PIADate = djs.toDate();
+  return piaDate;
 }
 
 //Parces a pia currency values
@@ -212,4 +304,12 @@ function parsePiaCurrency(val: string): Number {
 
 function parsePiaFloat(val: string): Number {
   return parseFloat(val);
+}
+
+function formatPIADateStr(date: PiaDate): string {
+  return dayjs(date).format("MMDDYYYY");
+}
+
+function formatPIAMonthStr(monthYear: PIAMonthYear): string {
+  return dayjs(monthYear).format("MMYYYY");
 }


### PR DESCRIPTION
I cleaned up the PIAFormat module. It now serializes and deserializes the first two lines.

I used the PIAFieldMeta (renamed from PIAFieldFormat to contain the start and ending positions of the fields in the lines.

I added a utility method to the class to generate blank spaces when the field is undefined for serialization.